### PR TITLE
Fix unit tests for R < 3.6.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@ inst/doc/.*\.tex
 ^\.travis\.yml$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+revdep

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,5 @@ vignettes/.*\.tex
 inst/doc/.*\.tex
 ^makefile$
 ^\.travis\.yml$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Rhistory
 .Rdata
 .DS_Store
+revdep/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .project
 .settings
+.Rproj.user
+.Rhistory
+.Rdata
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
-# Sample .travis.yml for R projects.
-#
-# See README.md for instructions, or for more configuration options,
-# see the wiki:
-#   https://github.com/craigcitro/r-travis/wiki
-
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 language: r
-sudo: false
-cache: packages
-r:
-  - release
-  - devel
-r_packages:
-  - covr
+
+dist: trusty
+sudo: true
+
 warnings_are_errors: false
+
+r:
+  - 3.2
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+  - devel
+
 after_success:
   - Rscript -e 'covr::codecov()'
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ sudo: true
 warnings_are_errors: false
 
 r:
-  - 3.1
   - 3.2
   - 3.3
   - 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ sudo: true
 warnings_are_errors: false
 
 r:
-  - 3.0
   - 3.1
   - 3.2
   - 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ sudo: true
 warnings_are_errors: false
 
 r:
+  - 3.0
+  - 3.1
   - 3.2
   - 3.3
   - 3.4

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL: https://renozao.github.io/rngtools
 BugReports: http://github.com/renozao/rngtools/issues
 Encoding: UTF-8
 Depends:
-    R (>= 3.0.0),
+    R (>= 3.2.0),
     methods,
     pkgmaker (>= 0.20)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rngtools
 Authors@R: person("Renaud", "Gaujoux", email = "renozao@protonmail.com", role = c("aut", "cre"))
-Version: 1.3.1
+Version: 1.3.1.2
 License: GPL-3
 Title: Utility Functions for Working with Random Number Generators
 Description: Provides a set of functions for working with
@@ -23,6 +23,7 @@ Imports:
     stats,
     parallel
 Suggests:
+    covr,
     RUnit,
     testthat
 Collate:

--- a/rngtools.Rproj
+++ b/rngtools.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -72,12 +72,12 @@ test_that('RNGdigest and RNGstr', {
 checkRNGtype <- function(x, ..., expL = NULL){
   
   if(is.null(expL)) {
-    # This switch accounts for the change inthe R RNG that occured in 3.6.0
+    # This switch accounts for the change in the R RNG that occured in 3.6.
     test_ver <- as.character(getRversion())
     if (compareVersion(test_ver, "3.6.0") > 0) {
-      expL <- 2L
-    } else {
       expL <- 3L
+    } else {
+      expL <- 2L
     }
   }
   

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -74,7 +74,7 @@ checkRNGtype <- function(x, ..., expL = NULL){
   if(is.null(expL)) {
     # This switch accounts for the change in the R RNG that occured in 3.6.
     test_ver <- as.character(getRversion())
-    if (compareVersion(test_ver, "3.6.0") > 0) {
+    if (compareVersion(test_ver, "3.6.0") >= 0) {
       expL <- 3L
     } else {
       expL <- 2L

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -1,6 +1,6 @@
 # Unit test 
 # 
-# Author: Renaud Gaujoux
+# Author: Renaud Gaujoux (edited by Max Kuhn)
 # Created: 01 May 2018
 # Copyright: Cytoreason (2017)
 ###############################################################################
@@ -9,6 +9,7 @@ context("Formatting functions")
 
 library(stringr)
 library(pkgmaker)
+library(utils)
 
 # RUnit-testthat bridge 
 checkIdentical <- function(x, y, msg){
@@ -68,7 +69,17 @@ test_that('RNGdigest and RNGstr', {
   
 })
 
-checkRNGtype <- function(x, ..., expL=2L){
+checkRNGtype <- function(x, ..., expL = NULL){
+  
+  if(is.null(expL)) {
+    # This switch accounts for the change inthe R RNG that occured in 3.6.0
+    test_ver <- as.character(getRversion())
+    if (compareVersion(test_ver, "3.6.0") > 0) {
+      expL <- 2L
+    } else {
+      expL <- 3L
+    }
+  }
   
   fn <- RNGtype
   oldRNG <- getRNG()


### PR DESCRIPTION
Recently one of the CRAN maintainers made [a few changes](https://github.com/cran/rngtools/commit/c9c036b18e0bf6f20afcab15a2b38083aaf62da7) to `rngtools` without notifications to the public (that I can find). This affects that package, `NMF`, and their reverse dependencies since they bumped the R version requirement to be >= 3.6.0. 

This PR fixes the original issue and lowers the version to 3.2.0